### PR TITLE
Implement basic authentication scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-  
+# Z Dating App
+
+This repository contains a minimal prototype for a dating application built with **FastAPI** and **Flutter**. It demonstrates a simple authentication flow using JWT tokens.
+
+## Backend
+
+- **Python 3.10** with [FastAPI](https://fastapi.tiangolo.com)
+- Asynchronous PostgreSQL access via `asyncpg`
+- User registration and login endpoints
+- JWT token generation (access & refresh)
+
+## Frontend
+
+The Flutter project provides only a skeleton at this stage. `lib/main.dart` runs a basic app that can be extended with actual UI screens.
+
+## Running locally
+
+1. Install Python dependencies:
+   ```bash
+   cd backend
+   pip install -r requirements.txt
+   ```
+2. Copy `.env` and adjust values as needed.
+3. Start the API:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+Flutter code can be launched using the standard `flutter run` command inside the `frontend` directory.
+

--- a/backend/app/api/api_v1/endpoints/auth.py
+++ b/backend/app/api/api_v1/endpoints/auth.py
@@ -1,7 +1,9 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from app.schemas.user import UserCreate
+
+from app.schemas.user import UserCreate, UserLogin, Token
 from app.services.user_service import create_user
+from app.services.auth_service import authenticate_user, generate_tokens
 from app.core.database import get_db
 from app.models.user import User
 
@@ -13,3 +15,12 @@ def signup(user: UserCreate, db: Session = Depends(get_db)):
     if db_user:
         raise HTTPException(status_code=400, detail="Email already registered")
     return create_user(db, user)
+
+
+@router.post("/login", response_model=Token)
+def login(user: UserLogin, db: Session = Depends(get_db)):
+    db_user = authenticate_user(db, user.email, user.password)
+    if not db_user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    access, refresh = generate_tokens(db_user.id)
+    return {"access_token": access, "refresh_token": refresh}

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -10,6 +10,8 @@ class Settings(BaseSettings):
     DEBUG: bool = True
     SECRET_KEY: str
     ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
     # DB
     DATABASE_URL: str

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -4,7 +4,9 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from app.core.config import settings
 
-engine = create_async_engine(settings.database_url, echo=True)
+# Pydantic에서 환경 변수는 대소문자를 구분하지 않지만
+# 코드 가독성을 위해 대문자 속성을 그대로 사용한다.
+engine = create_async_engine(settings.DATABASE_URL, echo=True)
 async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 # 의존성 주입용

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,10 @@
+from datetime import datetime, timedelta
+from typing import Any, Dict
+
+from jose import jwt
 from passlib.context import CryptContext
+
+from app.core.config import settings
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
@@ -7,3 +13,23 @@ def get_password_hash(password: str) -> str:
 
 def verify_password(plain_password: str, hashed_password: str) -> bool:
     return pwd_context.verify(plain_password, hashed_password)
+
+
+def create_access_token(data: Dict[str, Any], expires_minutes: int | None = None) -> str:
+    """Create a signed JWT access token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(
+        minutes=expires_minutes or settings.ACCESS_TOKEN_EXPIRE_MINUTES
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+
+def create_refresh_token(data: Dict[str, Any], expires_days: int | None = None) -> str:
+    """Create a signed JWT refresh token."""
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(
+        days=expires_days or settings.REFRESH_TOKEN_EXPIRE_DAYS
+    )
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -6,6 +6,11 @@ class UserCreate(BaseModel):
     email: EmailStr
     password: str = Field(..., min_length=8)
 
+
+class UserLogin(BaseModel):
+    email: EmailStr
+    password: str
+
 # ───────── 출력용 ─────────
 class UserRead(BaseModel):
     id: int
@@ -15,3 +20,8 @@ class UserRead(BaseModel):
 
     class Config:
         orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,1 +1,44 @@
-  
+from typing import Optional, Tuple
+
+from sqlalchemy.orm import Session
+
+from app.models.user import User
+from app.schemas.user import UserCreate
+from app.core.security import (
+    get_password_hash,
+    verify_password,
+    create_access_token,
+    create_refresh_token,
+)
+
+
+def create_user(db: Session, user_data: UserCreate) -> User:
+    """Persist a new user and return it."""
+    db_user = User(
+        email=user_data.email,
+        hashed_password=get_password_hash(user_data.password),
+        name=user_data.name,
+        age=user_data.age,
+        gender=user_data.gender,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def authenticate_user(db: Session, email: str, password: str) -> Optional[User]:
+    """Validate user credentials and return user if valid."""
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        return None
+    if not verify_password(password, user.hashed_password):
+        return None
+    return user
+
+
+def generate_tokens(user_id: int) -> Tuple[str, str]:
+    """Return access and refresh JWT tokens for the given user."""
+    access = create_access_token({"sub": str(user_id)})
+    refresh = create_refresh_token({"sub": str(user_id)})
+    return access, refresh

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -1,1 +1,14 @@
-  
+import 'package:flutter/material.dart';
+
+class ZDatingApp extends StatelessWidget {
+  const ZDatingApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Z Dating App',
+      theme: ThemeData(primarySwatch: Colors.pink),
+      home: const Placeholder(),
+    );
+  }
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,1 +1,7 @@
-  
+import 'package:flutter/material.dart';
+
+import 'app.dart';
+
+void main() {
+  runApp(const ZDatingApp());
+}


### PR DESCRIPTION
## Summary
- add project overview in README
- implement access and refresh token logic
- implement user login endpoint
- add authentication service
- include simple Flutter app skeleton

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68444792bcc08325807403964cdb8fc9